### PR TITLE
fix: incorrect fact scorer prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ All notable changes to this project will be documented in this file.
 - Add fact scorer demons json file
 - Add CONTRIBUTING.md guidelines
 
+## v 1.2.0 - 2024-04-19
+
+- Fix knowledge source in fact scorer prompt (used to send all knowledge sources in one prompt)
+
 <!--
 ### Added
 

--- a/FactScoreLite/factscore.py
+++ b/FactScoreLite/factscore.py
@@ -98,16 +98,18 @@ class FactScore:
         decisions = self.decisions_handler.load()
         scores = []
         init_scores = []
+        cur_knw_idx = 0
 
-        for enrty in decisions:
-            score, init_score = self.calculate_score(enrty["decision"])
+        for entry in decisions:
+            score, init_score = self.calculate_score(entry["decision"])
             init_scores.append(init_score)
             scores.append(score)
+            cur_knw_idx += 1
 
         for entry in tqdm(generation_facts_pairs[len(decisions) :]):
             generation, facts = entry["generation"], entry["facts"]
 
-            decision = self.fact_scorer.get_score(facts, knowledge_sources)
+            decision = self.fact_scorer.get_score(facts, knowledge_sources[cur_knw_idx])
             score, init_score = self.calculate_score(decision)
 
             init_scores.append(init_score)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = FactScoreLite
-version = 1.1.0
+version = 1.2.0
 author = armingh2000
 author_email = 
 license = MIT


### PR DESCRIPTION
instead of the related knowledge source, all kowledge items were in the prompt resulting in high costs. now it is only the related one.